### PR TITLE
Capability to export and import JSON

### DIFF
--- a/classes/class-cei-core.php
+++ b/classes/class-cei-core.php
@@ -277,7 +277,7 @@ final class CEI_Core {
 		$raw  = file_get_contents( $file['file'] );
 
 		switch ( $file['type'] ) {
-			case 'text/data':
+			case 'text/dat':
 				$data = @unserialize( $raw );
 				break;
 

--- a/customizer-export-import.php
+++ b/customizer-export-import.php
@@ -13,6 +13,7 @@
 define( 'CEI_VERSION', '0.1' );
 define( 'CEI_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'CEI_PLUGIN_URL', plugins_url( '/', __FILE__ ) );
+define( 'CEI_DISPLAY_JSON_EXPORT', FALSE );
 
 /* Classes */
 require_once CEI_PLUGIN_DIR . 'classes/class-cei-core.php';

--- a/includes/control.php
+++ b/includes/control.php
@@ -5,7 +5,7 @@
 	<?php _e( 'Click a button below to export the customization settings for this theme.', 'customizer-export-import' ); ?>
 </span>
 <input type="button" class="button" name="cei-export-button-php" value="<?php esc_attr_e( 'Export PHP', 'customizer-export-import' ); ?>" />
-<?php if (function_exists('json_encode')): ?>
+<?php if ( CEI_DISPLAY_JSON_EXPORT && function_exists('json_encode') ): ?>
 <input type="button" class="button" name="cei-export-button-json" value="<?php esc_attr_e( 'Export JSON', 'customizer-export-import' ); ?>" />
 <?php endif; ?>
 

--- a/includes/control.php
+++ b/includes/control.php
@@ -2,9 +2,12 @@
 	<?php _e( 'Export', 'customizer-export-import' ); ?>
 </span>
 <span class="description customize-control-description">
-	<?php _e( 'Click the button below to export the customization settings for this theme.', 'customizer-export-import' ); ?>
+	<?php _e( 'Click a button below to export the customization settings for this theme.', 'customizer-export-import' ); ?>
 </span>
-<input type="button" class="button" name="cei-export-button" value="<?php esc_attr_e( 'Export', 'customizer-export-import' ); ?>" />
+<input type="button" class="button" name="cei-export-button-php" value="<?php esc_attr_e( 'Export PHP', 'customizer-export-import' ); ?>" />
+<?php if (function_exists('json_encode')): ?>
+<input type="button" class="button" name="cei-export-button-json" value="<?php esc_attr_e( 'Export JSON', 'customizer-export-import' ); ?>" />
+<?php endif; ?>
 
 <hr class="cei-hr" />
 

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -4,15 +4,21 @@
 	
 		init: function()
 		{
-			$( 'input[name=cei-export-button]' ).on( 'click', CEI._export );
+			$( 'input[name=cei-export-button-php]' ).on( 'click', CEI._export_php );
+			$( 'input[name=cei-export-button-json]' ).on( 'click', CEI._export_json );
 			$( 'input[name=cei-import-button]' ).on( 'click', CEI._import );
 		},
 	
-		_export: function()
+		_export_php: function()
 		{
-			window.location.href = CEIConfig.customizerURL + '?cei-export=' + CEIConfig.exportNonce;
+			window.location.href = CEIConfig.customizerURL + '?cei-export-format=php&cei-export=' + CEIConfig.exportNonce;
 		},
-	
+
+		_export_json: function()
+		{
+			window.location.href = CEIConfig.customizerURL + '?cei-export-format=json&cei-export=' + CEIConfig.exportNonce;
+		},
+
 		_import: function()
 		{
 			var win			= $( window ),


### PR DESCRIPTION
This plugin is extremely useful, however serialized PHP can be hard to read, modify and diff (both manually and automatically, for all kinds of collaboration tools), so I - currently collaborating with others on a wordpress project - felt the need for another format. I chose JSON as it is very readable, well known and comes with all current PHP versions.

My small extension of your plugin adds a JSON export option and also allows for uploading settings in json format (only if available on current PHP runtime). 

I'm fairly new to the wordpress ecosystem, so I don't know:
- whether all the existence checks for the "json_*" functions (>= PHP 5.2.0) are required or useful
- whether a feature supported by serialize() that's not supported by JSON might be required (e.g. exporting classes)
